### PR TITLE
Remove Multi-project Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,9 @@ It will start a development server on http://localhost:8081 and the swagger docu
 
 #### Development Notes
 
-1. The current implementation of ByteBrain Server depends on modified version of Langchain AI which enables us to have
-   Multi-tenancy support. I've created a pull request for this
-   change [here](https://github.com/langchain-ai/langchain/pull/14174).
-2. Currently, some tables in this module are stored in a separate database, which is not ideal. We need to integrate
+1. Currently, some tables in this module are stored in a separate database, which is not ideal. We need to integrate
    these tables in one database.
-3. The customization of chatbot's prompt template not completed yet and needs more work.
+2. The customization of chatbot's prompt template not completed yet and needs more work.
 
 ### ByteBrain Dashboard
 

--- a/bytebrain-server/core/bots/discord/discord_bot.py
+++ b/bytebrain-server/core/bots/discord/discord_bot.py
@@ -196,8 +196,7 @@ async def on_message(message):
             qa = make_question_answering_chain(
                 websocket=None,
                 vector_store=weaviate,
-                prompt_template=config.discord.prompt,
-                tenant = None
+                prompt_template=config.discord.prompt
             )
 
             chat_history = ["FULL CHAT HISTORY:"] + annotate_history_with_turns_v2(

--- a/bytebrain-server/core/bots/web/auth.py
+++ b/bytebrain-server/core/bots/web/auth.py
@@ -21,6 +21,7 @@ from fastapi import HTTPException
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
+import os
 
 from core.dao.user_dao import UserInDB, UserDao, User
 

--- a/bytebrain-server/core/bots/web/routers/chat.py
+++ b/bytebrain-server/core/bots/web/routers/chat.py
@@ -72,8 +72,7 @@ async def websocket_chat_endpoint(websocket: WebSocket, apikey: str,
         qa = make_question_answering_chain(
             websocket=websocket,
             vector_store=weaviate,
-            prompt_template=config.webservice.prompt,
-            tenant=project.id
+            prompt_template=config.webservice.prompt
         )
 
         while True:

--- a/bytebrain-server/core/dao/project_dao.py
+++ b/bytebrain-server/core/dao/project_dao.py
@@ -96,6 +96,18 @@ class ProjectDao:
                             created_at=datetime.strptime(result[3], '%Y-%m-%d %H:%M:%S'),
                             description=result[4]) for result in results]
 
+    def get_all_projects_count(self) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                SELECT COUNT(*) FROM projects
+            ''')
+            result = cursor.fetchone()
+            if result:
+                return result[0]
+            else:
+                return 0
+
     def update_project(self, project: Project):
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()

--- a/bytebrain-server/core/llm/chains.py
+++ b/bytebrain-server/core/llm/chains.py
@@ -95,14 +95,11 @@ def make_doc_search(persistent_dir: str):
 def make_question_answering_chain(
         websocket: Optional[WebSocket],
         vector_store: VectorStore,
-        prompt_template: str,
-        tenant: str = None):
+        prompt_template: str):
     search_kwargs = {
         'k': 10,
         'fetch_k': 30
     }
-    if tenant:
-        search_kwargs['tenant'] = tenant
 
     # TODO: Find the best options for retrieving docs
     # search_type="similarity_score_threshold",

--- a/bytebrain-server/core/services/project_service.py
+++ b/bytebrain-server/core/services/project_service.py
@@ -59,6 +59,11 @@ class ProjectService:
             )
 
     def create_project(self, name: str, user_id: str, description: str) -> Project:
+        if self.project_dao.get_all_projects_count() >= 1:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="ByteBrain doesn't support multi-project yet!"
+            )
         project = Project.create(name, user_id, description)
         self.project_dao.create_project(project)
         return project

--- a/bytebrain-server/core/services/resource_service.py
+++ b/bytebrain-server/core/services/resource_service.py
@@ -148,7 +148,7 @@ class ResourceService:
                                         doc_source_type=ResourceType.Website.value,
                                         url=url)
         self.resource_dao.set_state(resource_id, ResourceState.Indexing)
-        self.vectorstore_service.index_docs(ids, docs, project_id)
+        self.vectorstore_service.index_docs(ids, docs)
         self.metadata_service.save_docs_metadata(docs)
         self.resource_dao.set_state(resource_id, ResourceState.Finished)
 
@@ -159,7 +159,7 @@ class ResourceService:
                                            doc_source_id=resource_id,
                                            doc_source_type=ResourceType.Webpage.value)
         self.resource_dao.set_state(resource_id, ResourceState.Indexing)
-        self.vectorstore_service.index_docs(ids, docs, project_id)
+        self.vectorstore_service.index_docs(ids, docs)
         self.metadata_service.save_docs_metadata(docs)
         self.resource_dao.set_state(resource_id, ResourceState.Finished)
 
@@ -169,7 +169,7 @@ class ResourceService:
                                       doc_source_id=resource_id,
                                       doc_source_type=ResourceType.Youtube.value)
         self.resource_dao.set_state(resource_id, ResourceState.Indexing)
-        self.vectorstore_service.index_docs(ids, docs, project_id)
+        self.vectorstore_service.index_docs(ids, docs)
         self.metadata_service.save_docs_metadata(docs)
         self.resource_dao.set_state(resource_id, ResourceState.Finished)
 
@@ -183,7 +183,7 @@ class ResourceService:
                                                   branch=branch,
                                                   paths=paths)
         self.resource_dao.set_state(resource_id, ResourceState.Indexing)
-        self.vectorstore_service.index_docs(ids, docs, project_id)
+        self.vectorstore_service.index_docs(ids, docs)
         self.metadata_service.save_docs_metadata(docs)
         self.resource_dao.set_state(resource_id, ResourceState.Finished)
 
@@ -215,7 +215,7 @@ class ResourceService:
         resource = self.resource_dao.get_by_id(resource_id)
         ids = self.metadata_service.get_docs_ids_by_source_id(resource_id)
         if resource:
-            self.vectorstore_service.delete_docs(ids, resource.project_id)
+            self.vectorstore_service.delete_docs(ids)
         self.metadata_service.delete_docs_by_resource_id(resource_id)
         self.resource_dao.delete_resource(resource_id)
 

--- a/bytebrain-server/core/services/vectorstore_service.py
+++ b/bytebrain-server/core/services/vectorstore_service.py
@@ -31,14 +31,14 @@ class VectorStoreService:
         self.index_name = index_name
         self.text_key = text_key
 
-    def delete_docs(self, ids: List[UUID], tenant: Optional[str]):
+    def delete_docs(self, ids: List[UUID]):
         # TODO: use batch operations like delete_objects if possible!
         # self.weaviate_client.batch.delete_objects('Zio', where=???)
         for id in ids:
-            if self.weaviate_client.data_object.exists(id, class_name=self.index_name, tenant=tenant):
-                self.weaviate_client.data_object.delete(id, class_name=self.index_name, tenant=tenant)
+            if self.weaviate_client.data_object.exists(id, class_name=self.index_name):
+                self.weaviate_client.data_object.delete(id, class_name=self.index_name)
 
-    def index_docs(self, uuids: List[UUID], docs: List[Document], tenant: Optional[str] = None):
+    def index_docs(self, uuids: List[UUID], docs: List[Document]):
         # self.weaviate_client.schema.add_class_tenants(class_name=self.index_name, tenants=[Tenant(tenant)])
         self.weaviate.from_documents(
             documents=docs,
@@ -46,7 +46,6 @@ class VectorStoreService:
             index_name=self.index_name,
             text_key=self.text_key,
             uuids=uuids,
-            tenant=tenant
         )
 
     @staticmethod
@@ -57,8 +56,7 @@ class VectorStoreService:
     def map_metadata_to_hashes(metadata: List[Dict[any, any]]) -> List[str]:
         return [d['doc_hash'] for d in metadata]
 
-    def upsert_docs(self, ids: List[UUID], docs: List[Document], old_metadata_list: List[Dict[any, any]],
-                    tenant: Optional[str] = None):
+    def upsert_docs(self, ids: List[UUID], docs: List[Document], old_metadata_list: List[Dict[any, any]]):
         assert (len(ids) == len(docs))
 
         doc_source_type = docs[0].metadata['doc_source_type']
@@ -104,7 +102,7 @@ class VectorStoreService:
                     )
 
         if len(removed_docs_ids) != 0:
-            self.delete_docs(removed_docs_ids, tenant)
+            self.delete_docs(removed_docs_ids)
 
         assert (len(changed_docs) == len(changed_docs))
 

--- a/bytebrain-server/pyproject.toml
+++ b/bytebrain-server/pyproject.toml
@@ -5,7 +5,7 @@ description = "ByteBrain: Chat with Your Documents!"
 authors = ["Milad Khajavi"]
 
 [tool.poetry.dependencies]
-python = "3.10.12"
+python = "3.10.13"
 fastapi = "^0.95.1"
 langchain = "0.0.344"
 openai = "1.3.7"


### PR DESCRIPTION
The LangChain team decided to move the support for the weaviate to a [separate module](https://github.com/langchain-ai/langchain-weaviate), so the pull request for enabling multi-tenancy [was closed](https://github.com/langchain-ai/langchain-weaviate). They commented that the support for multi-tenancy was added to the new module [here](https://github.com/langchain-ai/langchain-weaviate/pull/25).

As we no longer require multi-project support for ByteBrain, I disabled it through this PR.